### PR TITLE
Fixed broken link to release-cycle.md

### DIFF
--- a/contributing/development-cycle.md
+++ b/contributing/development-cycle.md
@@ -52,7 +52,7 @@ Scrum, by definition, is an iterative methodology for project management. This i
 There's no product owners or scrum master per se. However, scrum master tasks are in place and all contributors are expected to update issues via comments, tasks, linking their branches and pushing changes into their branches.
 
 #### Sprints
-Most new feature development tasks are expected to be completed between 2-4 sprints. Quality Assurance tasks are expected to be completed in a single sprint so that it can be released with consistency as detailed in the [release cycle document](./releases/release-cycle.md).
+Most new feature development tasks are expected to be completed between 2-4 sprints. Quality Assurance tasks are expected to be completed in a single sprint so that it can be released with consistency as detailed in the [release cycle document](./release-cycle.md).
 
 #### Roles
 "Our" version of Scrum cannot implement the standard roles in Scrum, however, we implement the following roles:


### PR DESCRIPTION
## Description
Resolves task, from #39:
> Fix [link](https://github.com/cotheca/docs/blob/2f50c3306743a5416ce7f1b54c5acc41f73a83e8/contributing/development-cycle.md?plain=1#L55C221-L55C274) address to `[release cycle document](./release-cycle.md)`


## Type of change]
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] My code follows the code style of this project.
- ~~My change requires a change to the documentation~~.
- ~~I have updated the documentation accordingly~~.
- [x] My code fulfills the issue/feature request objectives.
- ~~I have added tests to cover my changes (at least covers objectives)~~.
- [x] All new and existing tests passed.
